### PR TITLE
MMI features and Posibrain improvements

### DIFF
--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -1,13 +1,17 @@
 /obj/item/mmi
+	parent_type = /obj/item/organ/internal/brain/synth/mmi
 	name = "\improper Man-Machine Interface"
 	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity, that nevertheless has become standard-issue on Nanotrasen stations."
 	icon = 'icons/obj/assemblies/assemblies.dmi'
 	icon_state = "mmi_off"
 	base_icon_state = "mmi"
 	w_class = WEIGHT_CLASS_NORMAL
+	slot = ORGAN_SLOT_BRAIN
+	zone = BODY_ZONE_CHEST
+	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
 	var/braintype = "Cyborg"
 	var/obj/item/radio/radio = null //Let's give it a radio.
-	var/mob/living/brain/brainmob = null //The current occupant.
+	brainmob = null //The current occupant.
 	var/mob/living/silicon/robot = null //Appears unused.
 	var/obj/vehicle/sealed/mecha = null //This does not appear to be used outside of reference in mecha.dm.
 	var/obj/item/organ/internal/brain/brain = null //The actual brain
@@ -137,7 +141,8 @@
 	brain.organ_flags &= ~ORGAN_FROZEN
 	brain = null //No more brain in here
 
-/obj/item/mmi/proc/transfer_identity(mob/living/L) //Same deal as the regular brain proc. Used for human-->robot people.
+/obj/item/mmi/transfer_identity(mob/living/L) //Same deal as the regular brain proc. Used for human-->robot people.
+	..()
 	if(!brainmob)
 		set_brainmob(new /mob/living/brain(src))
 	brainmob.name = L.real_name

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -2,7 +2,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 
 /obj/item/mmi/posibrain
 	name = "positronic brain"
-	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves.<br>Can be transformed into an IPC brain with <b>Ctrl+Click</b>!"
+	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves."
 	icon = 'icons/obj/assemblies/assemblies.dmi'
 	icon_state = "posibrain"
 	base_icon_state = "posibrain"
@@ -86,31 +86,6 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	ask_role = input_seed
 	update_appearance()
 
-/obj/item/mmi/posibrain/CtrlClick(mob/user)
-	if(!brainmob?.mind || !brainmob)
-		to_chat(user, span_notice("You press the button and release it, but nothing happens because the positronic brain is inactive."))
-		return
-	else if(brainmob.ckey == user.ckey)
-		to_chat(brainmob, span_notice("You cannot press your button itself, so nothing happens."))
-		return
-	to_ipc_posi(user)
-	to_chat(user, span_notice("You press the button to transform the positronic brain into an IPC brain."))
-
-/obj/item/mmi/posibrain/proc/to_ipc_posi(mob/user)
-	var/obj/item/organ/internal/brain/synth/brain = new /obj/item/organ/internal/brain/synth
-	brainmob.container = null //Reset brainmob mmi var.
-	brainmob.forceMove(brain) //Throw mob into brain.
-	brainmob.set_stat(DEAD)
-	brainmob.emp_damage = 0
-	brainmob.reset_perspective() //so the brainmob follows the brain organ instead of the mmi. And to update our vision
-	brain.brainmob = brainmob //Set the brain to use the brainmob
-	brainmob = null //Set mmi brainmob var to null
-	src.forceMove(drop_location())
-	if(Adjacent(user))
-		user.put_in_hands(brain)
-	brain.organ_flags &= ~ORGAN_FROZEN
-	brain = null //No more brain in here
-	qdel(src)
 
 /obj/item/mmi/posibrain/proc/check_success()
 	searching = FALSE
@@ -156,6 +131,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	transfer_personality(user)
 
 /obj/item/mmi/posibrain/transfer_identity(mob/living/carbon/transfered_user)
+	..()
 	name = "[initial(name)] ([transfered_user])"
 	brainmob.name = transfered_user.real_name
 	brainmob.real_name = transfered_user.real_name

--- a/monkestation/code/modules/client/preferences/species_features/ipc.dm
+++ b/monkestation/code/modules/client/preferences/species_features/ipc.dm
@@ -117,40 +117,63 @@
 		return
 
 	if (value == "Compact MMI")
-		var/obj/item/mmi/new_mmi = new() // create a MMI
-		// create the brains
-		var/obj/item/organ/internal/brain/human_brain = new() //new
-		var/obj/item/organ/internal/brain/existing_brain = target.get_organ_slot(ORGAN_SLOT_BRAIN) //old
-
-		//new brain
-		human_brain.brainmob = existing_brain.brainmob
-		existing_brain.brainmob = null
-
+		// Gets the target's current brain
+		var/obj/item/organ/internal/brain/existing_brain = target.get_organ_slot(ORGAN_SLOT_BRAIN)
 		if (istype(existing_brain) && !existing_brain.decoy_override)
+			// Sets the name to use: if the existing brain's brainmob has a name, use it; otherwise, use the target's real_name
+			var/name_to_use = existing_brain.brainmob?.real_name
+			if (!name_to_use)
+				name_to_use = target.real_name
+
+			// --- Replicating make_mmi() inline ---
+			// Creates the new MMI from the target (note that we use the non-positronic version)
+			var/obj/item/mmi/new_mmi = new /obj/item/mmi(target)
+
+			// Creates a "standard" brain for the MMI
+			new_mmi.brain = new /obj/item/organ/internal/brain(new_mmi)
+			new_mmi.brain.organ_flags |= ORGAN_FROZEN
+			new_mmi.brain.name = "[name_to_use]'s brain"
+
+			// Updates the MMI name based on the first letter (or another desired format) and the chosen name
+			new_mmi.name = "[initial(new_mmi.name)]: [name_to_use]"
+
+			// Creates and assigns a new brainmob for the MMI
+			new_mmi.set_brainmob(new /mob/living/brain(new_mmi)) //existing_brain?.brainmob
+			new_mmi.brainmob.name = name_to_use
+			new_mmi.brainmob.real_name = name_to_use
+			new_mmi.brainmob.container = new_mmi
+
+			// Updates the MMI appearance
+			new_mmi.update_appearance()
+			// --- End of make_mmi() replication ---
+
+			// Now, let's transfer the human brain into the MMI.
+			// Creates a new brain that will receive the old human brainmob.
+			var/obj/item/organ/internal/brain/human_brain = new /obj/item/organ/internal/brain(new_mmi)
+			// Transfers the old brainmob to the new brain
+			human_brain.brainmob = existing_brain.brainmob
+			existing_brain.brainmob = null
+
+			// Performs the replacement routines for the old brain
 			existing_brain.before_organ_replacement(new_mmi)
 			existing_brain.Remove(target, special = TRUE, no_id_transfer = TRUE)
 			qdel(existing_brain)
 
-			// Agora colocamos o cérebro dentro do MMI, sem deletá-lo
-			// Insere o cérebro humano dentro do MMI
+			// Adjusts the flags and reapplies the appearance with the new (human) brain
 			human_brain.organ_flags |= ORGAN_FROZEN
 			new_mmi.brain = human_brain
 			new_mmi.update_appearance()
-			// new_mmi.brain = human_brain
-			new_mmi.set_brainmob(human_brain?.brainmob)
+			new_mmi.set_brainmob(human_brain.brainmob)
 			human_brain.brainmob = null
 
+			// If there is a brainmob, force its movement into the MMI and update the container
 			if (new_mmi.brainmob)
+			{
 				new_mmi.brainmob.forceMove(new_mmi)
 				new_mmi.brainmob.container = new_mmi
-
+			}
+			// Inserts the MMI into the target's body
 			new_mmi.Insert(target, special = TRUE, drop_if_replaced = FALSE)
-
-
 
 /datum/preference/choiced/ipc_brain/is_accessible(datum/preferences/preferences)
 	return ..() && (preferences.read_preference(/datum/preference/choiced/species) in list(/datum/species/ipc, /datum/species/synth))
-
-// var/mob/living/brain/B = newbrain.brainmob
-// 		if(!B.key)
-// 			B.notify_ghost_cloning("Someone has put your brain in a MMI!", source = src)


### PR DESCRIPTION
## About The Pull Request
This PR introduces the ability to use MMI (Man-Machine Interface) as a starting brain for Synths and allows MMI to be directly installed into both IPCs (Integrated Positronic Chassis) and Synths as brains. Additionally, Posibrains no longer require conversion before being installed into IPCs and Synths, making them more flexible and easier to use.

## Why It's Good For The Game
Makes it easier to give Synths and IPCs brains, with fewer steps and more customization options for players.

## Changelog
* Synths can now start with MMI as their brain.
* MMI can now be installed directly into IPCs and Synths.
* Posibrains no longer require conversion before being installed into IPCs and Synths.
